### PR TITLE
Use domain admin username as domain filter

### DIFF
--- a/mailscanner/lists.php
+++ b/mailscanner/lists.php
@@ -193,6 +193,8 @@ switch ($_SESSION['user_type']) {
             $ar = explode('@', $_SESSION['myusername']);
             $domainname = $ar[1];
             $to_domain_filter[] = $domainname;
+        } else {
+            $to_domain_filter[] = $_SESSION['myusername'];
         }
         $to_domain_filter = array_unique($to_domain_filter);
         break;


### PR DESCRIPTION
Domain administrators that have their domain name as user name are not able to set whitelist or blacklist entries for their domain unless it is explicitly added to the filters of the domain administrator user. 
However doing so results in duplicate email in the daily spam report.
This patch adds the domain administrator user name as domain filter.